### PR TITLE
[c] Tweaks and Centred markdown content

### DIFF
--- a/content/posts/Spyder TKL.md
+++ b/content/posts/Spyder TKL.md
@@ -9,29 +9,29 @@ tags = ["showcase","keyboards"]
 [extra]
 author = { name = "LogolicusZ", social= "https://www.instagram.com/logolicusz" }
 +++
- 
+
 <img src="/imgs/Spyder-article/Spyder5.jpeg" alt="Spyder TKL Images" title="Image by extra Prius" class="TitleImage">
 
-Photo by [Extrapriusplease](https://www.instagram.com/extrapriusplease.kb/)
+<p class="image-text">Photo by <a href="https://www.instagram.com/extrapriusplease.kb/">Extrapriusplease</a></p>
 
 In 1953, Porsche introduced the 550 Spyder into the market at a Paris Motor Show. Also its Win in the LeMans of the same year made it a pivotal moment in its history. The 550 was a car with a smaller chassis compared to all of its competitors at the time and it proved itself being aerodynamically superior.
-  
+
 Speeding trough the years, the spyder went trough numerous changes build up to the release of the 718 Spyder in 2015. Porsche payed homage to one of its best cars this past century, while still incorporating modern engineering advancements. The 718 features aggressive fron edges and a spoiler reminiscent of the 718 Boxster.
-  
+
 <img src="/imgs/Spyder-article/car1.jpg" alt="Spyder 550" title="Image by extra Prius" class="carImage">
-  
-Photo by [Markus Spiske](https://unsplash.com/photos/a-close-up-of-a-car-parked-in-a-field-UhTNl-xLOCU)  
+
+<p class="image-text">Photo by <a href="https://unsplash.com/photos/a-close-up-of-a-car-parked-in-a-field-UhTNl-xLOCU">Markus Spiske</a></p>
 
 Tho the Inspiration on of the Porsche is very light, as some of you that have been in this hobby for a while, will have noticed the a familiar sight of a particular wedge, its from the OTD360 corsa! The Corsa was first shown of 2014 on an Geekhack thread and has its particular wedge has shown up in multiple keyboards since then.
-  
+
 The Spyder effortlessly blends classic and modern design aspects, which have been seen in multiple of the most influentaial boards in this hobby. Creating a timeless piece that will look good on every desk you put it on. Plyworks also opted to use the Hiney87 pcb layout ensuring that the buyers can get replacement PCB easily.  
 
 <img src="/imgs/Spyder-article/Spyder6.jpg" alt="Spyder 550" title="Image by Captainsterling" class="TitleImage">
-   
-Photo by [Captain Sterling](https://www.instagram.com/p/C4Dlw5-OCrH/?hl=en&img_index=1)
-    
+
+<p class="image-text">Photo by <a href="https://www.instagram.com/p/C4Dlw5-OCrH/?hl=en&img_index=1">Captain Sterling</a></p>
+
 Plywrks has set a minimum of 50 boards for his GB but wants to leave it uncapped, so that anyone who decides they do want the board still get the chance to pick it up. As many other designers, Plywrks decided to keep most of the information and updates on this board of Geek Hack but rather releasing more infos on his Discord and Instagram. Which will be linked below.
-    
+
 In the past few years we have seen that many boards have taken inspirations from other mediums, one of its favorite mediums being Anime. The Designer has managed to define what it means to be "inspired" without having direct elements of the other medium creating a look that is classic but at the same time original.
 Check out Plywrks social if you want to know more about the board! The groupbuy for the Spyder TKL is to take place in May of 2024.
 
@@ -39,7 +39,8 @@ Check out Plywrks social if you want to know more about the board! The groupbuy 
 
 <iframe  src="https://www.youtube.com/embed/cQe-mQUS7KI?si=hxLRQGXMZsIjuqr7" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
   
-## Socials  
+## Socials
+
 Plywrks [Instagram](https://www.instagram.com/plywrks)
-  
+
 Plywrks [Discord](https://discord.com/invite/rwBM7tpchE)

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -466,3 +466,19 @@ table td {
   align-items: center;
   grid-column-gap: 10px;
 }
+
+/* markdown content tweaks */
+
+section.body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+p, h1, h2, h3, h4, h5, h6, code, pre {
+  align-self: flex-start;
+}
+
+p.image-text {
+  align-self: center;
+}

--- a/sass/css/fonts.scss
+++ b/sass/css/fonts.scss
@@ -1,2 +1,1 @@
 @import url("../../themes/archie-zola/static/css/fonts.css");
-

--- a/sass/css/main.scss
+++ b/sass/css/main.scss
@@ -1,3 +1,1 @@
 @import url("../../themes/archie-zola/static/css/main.css");
-
-  


### PR DESCRIPTION
With my changes in the archie-zola theme, you can centre images, videos, or whatever else, with a configurable reset.

```css
/* starting at line 469 */
p, h1, h2, h3, h4, h5, h6, code, pre {
  align-self: flex-start;
}
```

The above code is a reset for elements that shouldn't be centred. Feel free to add onto that list, I've chosen some initial values.

When merged, You'll also be able to centre and add an image's alt text like this in a post:

```html
<!-- example alt text for image -->
<img src="/imgs/Spyder-article/Spyder5.jpeg" alt="Spyder TKL Images" title="Image by extra Prius" class="TitleImage">
<p class="image-text">Photo by <a href="https://www.instagram.com/extrapriusplease.kb/">Extrapriusplease</a></p>
```

Add a paragraph with the `image-text` class to centre it.

I've also removed some unnecessary lines in the site's SCSS files.

I hope my changes here have improved the looks of the website ;D